### PR TITLE
Fix typos and update linter versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ git commit -m "Initialize repository with default project template"
 $ git push origin
 ```
 
-Approach 2 (initalize git locally and push to remote):
+Approach 2 (initialize git locally and push to remote):
 
 ```bash
 # install cookiecutter if not yet installed

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,11 +18,11 @@ Install **cookiecutter>=2.1.1** first and then point it to git repository / loca
 
 ## How to initialize new repository with the template
 
-Firstly, you need to create a new project. We use following convention for project name: 
+Firstly, you need to create a git project. The suggested name convention is:
 
 `<client_name>-<project_name>`
 
-For you, instead of client name you can use your or company name as a prefix.
+Where `client_name` is the name of the client can also be your own name or name of the company you work for. `project_name` is the name of the project.
 
 GIT-SSH is the SSH link to the repository you want to initialize.
 

--- a/docs/template_structure.md
+++ b/docs/template_structure.md
@@ -33,7 +33,7 @@ hooks/post_gen_project.py
 - **pre hook** - to validate variables content before cookiecutter generates files.
   - e.g. check if python package name provided by a user is correct
 - **post hook** - second allows to clean up unnecessary files that are not needed or run additional code.
-  - e.g. remove unnessary files, fix file permissions etc.
+  - e.g. remove unnecessary files, fix file permissions etc.
 
 ## Project template directory
 

--- a/docs/tmp_content/gitlab_ci.md
+++ b/docs/tmp_content/gitlab_ci.md
@@ -79,7 +79,7 @@ use `git rev-parse HEAD`, also GitLab has `$CI_COMMIT_SHA` environment variable.
         - reports code % coverage
         - ![Tests](../_static/tests.png)
     - checks for licenses
-        - fails if any third-party installed python package license is not present on whitelist (`.license-whitelist.txt`).
+        - fails if any third-party installed python package license is not present on allowlist (`.license-whitelist.txt`).
     - generates `pip freeze`
     - **artifacts:** exact pinned package versions + licenses can be downloaded from this stage
 * **package** stage:

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.4.0
+      rev: v4.5.0
       hooks:
           - id: check-case-conflict
           - id: check-merge-conflict
@@ -31,7 +31,7 @@ repos:
 
     # Modernizes python code and upgrade syntax for newer versions of the language
     - repo: https://github.com/asottile/pyupgrade
-      rev: v3.12.0
+      rev: v3.15.0
       hooks:
           - id: pyupgrade
             args: [--py38-plus]
@@ -42,6 +42,8 @@ repos:
       hooks:
           - id: mypy
             args: []
+            # You can add additional plugins for mypy below
+            # such as types-python-dateutil
             additional_dependencies: []
             exclude: (/test_|setup.py|/tests/|docs/)
 
@@ -67,17 +69,19 @@ repos:
 
       # Enforces a coding standard, looks for code smells, and can make suggestions about how the code could be refactored.
     - repo: https://github.com/pycqa/pylint
-      rev: v3.0.0a7
+      rev: v3.0.1
       hooks:
           - id: pylint
             exclude: (/test_|tests/|docs/)
-            additional_dependencies:
-              - 'pylint_pydantic'
-            args:
-              # pylint can have issue with python libraries based on C
-              # if it fails to find some objects likely you need to add them
-              # here:
-              ["--extension-pkg-whitelist=pydantic"]
+            # # You can add additional plugins for pylint here,
+            # here is an example for pydantic, remember to enable it in pyproject.toml
+            # additional_dependencies:
+            #   - 'pylint_pydantic'
+            # args:
+            #   # pylint can have issue with python libraries based on C
+            #   # if it fails to find some objects likely you need to add them
+            #   # here:
+            #   ["--extension-pkg-whitelist=pydantic"]
 
       # Finds common security issues in Python code.
     - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -1,6 +1,7 @@
 # {{cookiecutter.project_name}}
 
 Repository is created with deepsense.ai project template boilerplate. Adapt to your needs.
+Documentation is available at [https://deepsense-ai.github.io/ds-template/](https://deepsense-ai.github.io/ds-template/).
 
 
 # Setup developer environment
@@ -49,7 +50,7 @@ See also [Cookiecutter Data Science opinion](https://drivendata.github.io/cookie
 
 # Project documentation
 
-In `docs/` directory are Sphinx RST files.
+In `docs/` directory are Sphinx RST/Markdown files.
 
 To build documentation locally, in your configured environment, you can use `build_docs.sh` script:
 
@@ -59,7 +60,7 @@ $ ./build_docs.sh
 
 Then open `public/index.html` file.
 
-Please read the offical [Sphinx documentation](https://www.sphinx-doc.org/en/master/) for more details.
+Please read the official [Sphinx documentation](https://www.sphinx-doc.org/en/master/) for more details.
 
 {% if cookiecutter.ci == "GitLab" %}
 
@@ -93,7 +94,7 @@ $ ./bump_version.sh --dry-run major
 ```
 Script updates **VERSION** file and setup.cfg automatically uses that version.
 
-You can configure it to update version string in other files as well - check bump2version configuration please.
+You can configure it to update version string in other files as well - please check out the bump2version configuration file.
 
 {% if cookiecutter.ci == "GitLab" %}
 

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -100,7 +100,7 @@ good-names="""i,j,x,y,z,x1,y1,z1,x2,y2,z2,cv,df,dx,dy,dz,w,h,c,b,g,qa,q,a""""
 max-args=8
 
 [tool.pylint.main]
-load-plugins=["pylint.extensions.docparams", "pylint_pydantic"]
+load-plugins=["pylint.extensions.docparams"]
 
 [tool.pylint.messages_control]
 disable=[


### PR DESCRIPTION
Collection of typos in docs and other small tweaks.
Updated linter versions to newest one.
Disabled pylint_pydantic - it stopped work now with precommit - it fails to import it's dependency and well-known fixes I tried did not work. However leaved it as comment.