### PR TITLE
Fix bandit in pre-commit hook and update linters 

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
 
       # PEP 8 compliant opinionated formatter.
     - repo: https://github.com/psf/black
-      rev: 23.9.1
+      rev: 23.10.1
       hooks:
           - id: black
             exclude: (docs/)
@@ -23,7 +23,7 @@ repos:
 
       # Cleaning unused imports.
     - repo: https://github.com/hadialqattan/pycln
-      rev: v2.2.2
+      rev: v2.3.0
       hooks:
           - id: pycln
             args: ["-a"]

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -84,8 +84,9 @@ repos:
             #   ["--extension-pkg-whitelist=pydantic"]
 
       # Finds common security issues in Python code.
-    - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-      rev: v1.0.6
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.7.5
       hooks:
-          - id: python-bandit-vulnerability-check
-            args: [-c, pyproject.toml, --recursive, src, -ll]
+          - id: bandit
+            args: [-c, pyproject.toml, --recursive, src]
+            additional_dependencies: [".[toml]"] # required for pyproject.toml support

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -140,3 +140,6 @@ min-similarity-lines=10
 
 [tool.bandit]
 exclude_dirs = ["venv",]
+# B101 disables errors for asserts in the code
+# remember to not use asserts for security and control flows
+skips = ["B101"]


### PR DESCRIPTION
- switch provider to PyCQA for the bandit
- update bandit version
- fix issue with incorrect pyproject.toml support in bandit
- relax bandit check to disable B101 - asserts are okay in code
- run pre-commit autoupdate